### PR TITLE
fix: incorrect example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,12 @@ const Input: Component<{name:string, label:string}> = (props) => {
   
   return (
     <>
-      <label for={props.id}>
+      <label for={props.name}>
         {props.label}
         {field.required() ? " *" : ""}
       </label>
       <input
+        name={props.name}
         value={field.value()}
         //@ts-ignore
         use:formHandler //still need to properly type the handler


### PR DESCRIPTION
### tl;dr

- [x] Adjusts README example so it works with a copy/paste

### Description

I was hoping to use `solid-js-form` for a project I'm working on. I noticed the example didn't work. After taking a look under the hood, I realized it's just because the example is missing the `name` attribute on `Input`. This PR puts it in place so others will be able to get up and running faster.